### PR TITLE
Ensure System.exit() is called

### DIFF
--- a/src/main/java/dk/dbc/kafka/LogTracerApp.java
+++ b/src/main/java/dk/dbc/kafka/LogTracerApp.java
@@ -23,14 +23,14 @@ public class LogTracerApp {
     public static void main(String[] args) {
         try {
             runWith(args);
-        } catch (ParseException | RuntimeException e) {
+        } catch (ParseException | org.apache.commons.cli.ParseException | RuntimeException e) {
             e.printStackTrace();
             System.exit(-1);
         }
         System.exit(0);
     }
 
-    static void runWith(String[] args) throws ParseException {
+    static void runWith(String[] args) throws ParseException, org.apache.commons.cli.ParseException {
         LOGGER.info("Log tracer has been started");
 
         Cli cliParser = null;
@@ -38,15 +38,8 @@ public class LogTracerApp {
         try {
             cliParser = new Cli(args);
             cmdLine = cliParser.parse();
-        } catch (ParseException | RuntimeException e) {
-            if (cliParser != null) {
-                cliParser.showHelp();
-            }
-            throw e;
-        }
-        if(cmdLine != null) {
-            Consumer consumer = new Consumer();
-            try {
+            if(cmdLine != null) {
+                Consumer consumer = new Consumer();
                 String hostname = cmdLine.hasOption("hostname") ? ((String) cmdLine.getParsedOptionValue("hostname")) : "localhost";
                 String port = cmdLine.hasOption("port") ? ((Number) cmdLine.getParsedOptionValue("port")).toString() : "2081";
                 String topic = cmdLine.hasOption("topic") ? ((String) cmdLine.getParsedOptionValue("topic")) : "test";
@@ -65,7 +58,7 @@ public class LogTracerApp {
 
                 // relevant env,host or app-id
                 if(cmdLine.hasOption("data-env")){
-                  consumer.setEnv(((String) cmdLine.getParsedOptionValue("data-env")));
+                    consumer.setEnv(((String) cmdLine.getParsedOptionValue("data-env")));
                     LOGGER.info("Filtering on environment " + consumer.getEnv());
 
                 }
@@ -94,10 +87,12 @@ public class LogTracerApp {
                 }else {
                     List<LogEvent> x = consumer.readLogEventsFromTopic(hostname, port, topic, UUID.randomUUID().toString(), offset, clientID, 0);
                 }
-            } catch (Exception e) {
-                e.printStackTrace();
-                LOGGER.severe("Log Tracer could not retrieve records from Kafka topic.");
             }
+        } catch (ParseException | org.apache.commons.cli.ParseException | RuntimeException e) {
+            if (cliParser != null) {
+                cliParser.showHelp();
+            }
+            throw e;
         }
     }
 }

--- a/src/main/java/dk/dbc/kafka/LogTracerApp.java
+++ b/src/main/java/dk/dbc/kafka/LogTracerApp.java
@@ -5,7 +5,7 @@ import dk.dbc.kafka.logformat.LogEvent;
 import org.apache.commons.cli.CommandLine;
 import org.slf4j.event.Level;
 
-
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -15,14 +15,22 @@ import java.util.logging.Logger;
 /**
  * Log tracer
  */
-public class LogTracerApp
-{
+public class LogTracerApp {
     private static Logger LOGGER = Logger.getLogger("LogTracerApp");
     private static String pattern = "yyyy-MM-dd'T'HH:mm";
     private static SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
 
-    public static void main(String[] args)
-    {
+    public static void main(String[] args) {
+        try {
+            runWith(args);
+        } catch (ParseException | RuntimeException e) {
+            e.printStackTrace();
+            System.exit(-1);
+        }
+        System.exit(0);
+    }
+
+    static void runWith(String[] args) throws ParseException {
         LOGGER.info("Log tracer has been started");
 
         Cli cliParser = null;
@@ -30,12 +38,11 @@ public class LogTracerApp
         try {
             cliParser = new Cli(args);
             cmdLine = cliParser.parse();
-        }catch (Exception e){
-            e.printStackTrace();
+        } catch (ParseException | RuntimeException e) {
             if (cliParser != null) {
                 cliParser.showHelp();
-              //  System.exit(0);
             }
+            throw e;
         }
         if(cmdLine != null) {
             Consumer consumer = new Consumer();

--- a/src/main/java/dk/dbc/kafka/ProduceTestData.java
+++ b/src/main/java/dk/dbc/kafka/ProduceTestData.java
@@ -12,7 +12,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.logging.Level;
 
 
 public class ProduceTestData {
@@ -27,9 +26,8 @@ public class ProduceTestData {
      * @param hostname kafkahost
      * @param port kafkaport
      * @param topicName name of the topic
-     * @throws Exception
      */
-    public void produceTestData(String hostname, String port, String topicName )throws Exception {
+    public void produceTestData(String hostname, String port, String topicName ) {
 
 
         //Configure the ProduceTestData

--- a/src/main/java/dk/dbc/kafka/ProduceTestData.java
+++ b/src/main/java/dk/dbc/kafka/ProduceTestData.java
@@ -28,9 +28,6 @@ public class ProduceTestData {
      * @param topicName name of the topic
      */
     public void produceTestData(String hostname, String port, String topicName ) {
-
-
-        //Configure the ProduceTestData
         Properties configProperties = new Properties();
         configProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, hostname + ":" + port);
         configProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,"org.apache.kafka.common.serialization.ByteArraySerializer");
@@ -38,27 +35,28 @@ public class ProduceTestData {
 
         org.apache.kafka.clients.producer.Producer producer = new KafkaProducer(configProperties);
 
-        Thread thread = new Thread(){
-            public void run(){
-
-                while(true) {
-                    try {
-                        LogEvent logEvent = createDummyObject(counter++);
-                        ProducerRecord<String, String> rec = new ProducerRecord<String, String>(topicName,logEvent.toJSON());
-                        System.out.println("Generating log event. " + logEvent.toJSON());
-                        producer.send(rec);
-                        sleep(500);
-                    } catch (InterruptedException e) {
-                        producer.close();
-                        System.out.println("### Generated " + counter + " message(s)");
-                        e.printStackTrace();
-                    }
+        final Thread thread = new Thread(() -> {
+            while(true) {
+                try {
+                    LogEvent logEvent = createDummyObject(counter++);
+                    ProducerRecord<String, String> rec = new ProducerRecord<>(topicName, logEvent.toJSON());
+                    System.out.println("Generating log event. " + logEvent.toJSON());
+                    producer.send(rec);
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    producer.close();
+                    System.out.println("### Generated " + counter + " message(s)");
+                    e.printStackTrace();
                 }
             }
-        };
+        });
 
         thread.start();
-
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
 

--- a/src/test/java/dk/dbc/kafka/LogTracerConsumerTest.java
+++ b/src/test/java/dk/dbc/kafka/LogTracerConsumerTest.java
@@ -284,7 +284,7 @@ public class LogTracerConsumerTest {
 
 
     @Test
-    public void testLogTracer(){
+    public void testLogTracer() throws ParseException {
         KafkaProducer<Integer, byte[]> producer = new KafkaProducer<>(producerProps);
 
         // send pre-formatted messages
@@ -314,7 +314,7 @@ public class LogTracerConsumerTest {
 
 
     @Test
-    public void testFileOutput(){
+    public void testFileOutput() throws ParseException {
 
         String[] args = new String[4];
         args[0] = "--hostname=" + BROKERHOST;
@@ -327,7 +327,7 @@ public class LogTracerConsumerTest {
     }
 
     @Test
-    public void testEmptyTopicLogTracer(){
+    public void testEmptyTopicLogTracer() throws ParseException {
         String[] args = new String[3];
         args[0] = "--hostname=" + BROKERHOST;
         args[1] = "--port=" + BROKERPORT;
@@ -336,7 +336,7 @@ public class LogTracerConsumerTest {
     }
 
     @Test
-    public void testNoHostnameLogTracer(){
+    public void testNoHostnameLogTracer() throws ParseException {
         String[] args = new String[3];
         args[0] = "--port=" + BROKERPORT;
         args[1] = "--topic=" + "not_a_topic";

--- a/src/test/java/dk/dbc/kafka/LogTracerConsumerTest.java
+++ b/src/test/java/dk/dbc/kafka/LogTracerConsumerTest.java
@@ -284,7 +284,7 @@ public class LogTracerConsumerTest {
 
 
     @Test
-    public void testLogTracer() throws ParseException {
+    public void testLogTracer() throws ParseException, org.apache.commons.cli.ParseException {
         KafkaProducer<Integer, byte[]> producer = new KafkaProducer<>(producerProps);
 
         // send pre-formatted messages
@@ -314,7 +314,7 @@ public class LogTracerConsumerTest {
 
 
     @Test
-    public void testFileOutput() throws ParseException {
+    public void testFileOutput() throws ParseException, org.apache.commons.cli.ParseException {
 
         String[] args = new String[4];
         args[0] = "--hostname=" + BROKERHOST;
@@ -327,7 +327,7 @@ public class LogTracerConsumerTest {
     }
 
     @Test
-    public void testEmptyTopicLogTracer() throws ParseException {
+    public void testEmptyTopicLogTracer() throws ParseException, org.apache.commons.cli.ParseException {
         String[] args = new String[3];
         args[0] = "--hostname=" + BROKERHOST;
         args[1] = "--port=" + BROKERPORT;
@@ -336,7 +336,7 @@ public class LogTracerConsumerTest {
     }
 
     @Test
-    public void testNoHostnameLogTracer() throws ParseException {
+    public void testNoHostnameLogTracer() throws ParseException, org.apache.commons.cli.ParseException {
         String[] args = new String[3];
         args[0] = "--port=" + BROKERPORT;
         args[1] = "--topic=" + "not_a_topic";

--- a/src/test/java/dk/dbc/kafka/LogTracerConsumerTest.java
+++ b/src/test/java/dk/dbc/kafka/LogTracerConsumerTest.java
@@ -1,5 +1,27 @@
 package dk.dbc.kafka;
 
+import dk.dbc.kafka.logformat.LogEvent;
+import kafka.admin.AdminUtils;
+import kafka.admin.RackAwareMode;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.SystemTime$;
+import kafka.utils.TestUtils;
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
+import kafka.zk.EmbeddedZookeeper;
+import org.I0Itec.zkclient.ZkClient;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -15,26 +37,8 @@ import java.util.Scanner;
 import java.util.UUID;
 import java.util.logging.Logger;
 
-import dk.dbc.kafka.logformat.LogEvent;
-import kafka.utils.SystemTime$;
-import org.I0Itec.zkclient.ZkClient;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.*;
-import static org.junit.Assert.*;
-
-import kafka.admin.AdminUtils;
-import kafka.admin.RackAwareMode;
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaServer;
-import kafka.utils.TestUtils;
-import kafka.utils.ZKStringSerializer$;
-import kafka.utils.ZkUtils;
-import kafka.zk.EmbeddedZookeeper;
-import org.junit.runners.MethodSorters;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -305,7 +309,7 @@ public class LogTracerConsumerTest {
         args[0] = "--hostname=" + BROKERHOST;
         args[1] = "--port=" + BROKERPORT;
         args[2] = "--topic=" + TOPIC_JSON + "xx";
-        LogTracerApp.main(args);
+        LogTracerApp.runWith(args);
     }
 
 
@@ -318,7 +322,7 @@ public class LogTracerConsumerTest {
         args[2] = "--topic=" + TOPIC_JSON;
         args[3] = "--store=" + "fileoutput.json";
 
-        LogTracerApp.main(args);
+        LogTracerApp.runWith(args);
 
     }
 
@@ -328,7 +332,7 @@ public class LogTracerConsumerTest {
         args[0] = "--hostname=" + BROKERHOST;
         args[1] = "--port=" + BROKERPORT;
         args[2] = "--topic=" + "not_a_topic";
-        LogTracerApp.main(args);
+        LogTracerApp.runWith(args);
     }
 
     @Test
@@ -336,7 +340,7 @@ public class LogTracerConsumerTest {
         String[] args = new String[3];
         args[0] = "--port=" + BROKERPORT;
         args[1] = "--topic=" + "not_a_topic";
-        LogTracerApp.main(args);
+        LogTracerApp.runWith(args);
     }
 
 


### PR DESCRIPTION
My guess is it was omitted because it broke the surefire tests calling
main. It sucks though to have a cli tool which doesn't exit on its own.

Issue #9