### PR TITLE
Utilize kafka time based log indexes

### DIFF
--- a/src/main/java/dk/dbc/kafka/Consumer.java
+++ b/src/main/java/dk/dbc/kafka/Consumer.java
@@ -10,16 +10,23 @@ import dk.dbc.kafka.logformat.LogEventMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
 
 import java.io.UncheckedIOException;
+import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class Consumer implements Iterable<LogEvent> {
     private final Properties kafkaConsumerProperties;
     private final String topicName;
     private final LogEventMapper logEventMapper;
+    private long timestamp;
 
     public Consumer(String hostname, Integer port, String topicName, String groupId, String offset, String clientID) {
         this.topicName = topicName;
@@ -27,12 +34,16 @@ public class Consumer implements Iterable<LogEvent> {
         this.logEventMapper = new LogEventMapper();
     }
 
+    public void setFromDateTime(OffsetDateTime dateTime) {
+        this.timestamp = dateTime.toInstant().toEpochMilli();
+    }
+
     @Override
     public Iterator<LogEvent> iterator() {
         return new Iterator<LogEvent>() {
             final KafkaConsumer<Integer, byte[]> kafkaConsumer = new KafkaConsumer<>(kafkaConsumerProperties);
             {
-                kafkaConsumer.subscribe(Collections.singletonList(topicName));
+                subscribe(kafkaConsumer, topicName, timestamp);
             }
             ConsumerRecords<Integer, byte[]> records;
             Iterator<ConsumerRecord<Integer, byte[]>> recordsIterator;
@@ -72,5 +83,28 @@ public class Consumer implements Iterable<LogEvent> {
         consumerProps.put("auto.offset.reset", offset);  // The consumer can starts from the beginning of the topic or the end
         consumerProps.put("max.poll.records", "100");
         return consumerProps;
+    }
+
+    private void subscribe(KafkaConsumer<Integer, byte[]> kafkaConsumer, String topicName, long timestamp) {
+        if (timestamp > 0) {
+            seekToOffsetsForTimestamp(kafkaConsumer, topicName, timestamp);
+        } else {
+            kafkaConsumer.subscribe(Collections.singletonList(topicName));
+        }
+    }
+
+    private void seekToOffsetsForTimestamp(KafkaConsumer<Integer, byte[]> kafkaConsumer, String topicName, long timestamp) {
+        final List<TopicPartition> topicPartitions = kafkaConsumer.partitionsFor(topicName)
+                .stream()
+                .map(partitionInfo -> new TopicPartition(topicName, partitionInfo.partition()))
+                .collect(Collectors.toList());
+        kafkaConsumer.assign(topicPartitions);
+
+        final Map<TopicPartition, Long> request = new HashMap<>();
+        topicPartitions.forEach(partition -> request.put(partition, timestamp));
+        kafkaConsumer.offsetsForTimes(request).entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .forEach(entry -> kafkaConsumer.seek(
+                        entry.getKey(), entry.getValue().offset()));
     }
 }

--- a/src/main/java/dk/dbc/kafka/logformat/LogEventFilter.java
+++ b/src/main/java/dk/dbc/kafka/logformat/LogEventFilter.java
@@ -16,10 +16,15 @@ public class LogEventFilter implements Predicate<LogEvent> {
     private OffsetDateTime from, until;
     private String appID, host, env;
     private Level loglevel;
+    private int numberOfExitEvents;
 
     public LogEventFilter setFrom(Date from) {
         this.from = OffsetDateTime.ofInstant(from.toInstant(), ZoneId.systemDefault());
         return this;
+    }
+
+    public OffsetDateTime getFrom() {
+        return from;
     }
 
     public LogEventFilter setUntil(Date until) {
@@ -47,6 +52,10 @@ public class LogEventFilter implements Predicate<LogEvent> {
         return this;
     }
 
+    public int getNumberOfExitEvents() {
+        return numberOfExitEvents;
+    }
+
     @Override
     public boolean test(LogEvent logEvent) {
         boolean allowed = true;
@@ -57,6 +66,7 @@ public class LogEventFilter implements Predicate<LogEvent> {
 
         if (until != null && (logEvent.getTimestamp() == null || logEvent.getTimestamp().isAfter(until))) {
             allowed = false;
+            numberOfExitEvents++;
         }
 
         if (appID != null && !appID.isEmpty() && !appID.equalsIgnoreCase(logEvent.getAppID())) {


### PR DESCRIPTION
When specifying --log-from filter to efficiently get from times to
exact offsets in each topic partition.